### PR TITLE
22.04 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- added support for Ubuntu 22.04
+
 ### Added
 ### Changed
 ### Removed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,18 @@ docker_pkg: "docker-ce"
 docker_release_versions:
   xenial: "18.03.0~ce-0~ubuntu"
   focal: "5:20.10.5~3-0~ubuntu-focal"
+  jammy: "5:20.10.14~3-0~ubuntu-jammy"
 docker_version: "{{ docker_release_versions[ansible_distribution_release] }}"
-docker_python_version: "3.4.1"
-docker_compose_python_version: "1.21.2"
+docker_python_versions:
+  xenial: "3.4.1"
+  focal: "3.4.1"
+  jammy: "5.0.3"
+docker_python_version: "{{ docker_python_versions[ansible_distribution_release] }}"
+docker_compose_versions:
+  xenial: "1.21.2"
+  focal: "1.21.2"
+  jammy: "1.29.2"
+docker_compose_python_version: "{{ docker_compose_versions[ansible_distribution_release] }}"
 docker_apt_key: |
   -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,7 @@
           - python3-pip
         state: present
         update_cache: yes
+
     - name: "Include appsembler_docker_ce_role"
       include_role:
         name: "appsembler_docker_ce_role"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,6 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
+  - name: ubuntu2204
+    image: geerlingguy/docker-ubuntu2204-ansible
+    pre_build_image: True
   - name: ubuntu2004
     image: geerlingguy/docker-ubuntu2004-ansible
     pre_build_image: True


### PR DESCRIPTION
This role is slightly less necessary with 22.04 since you can just do `apt install docker.io` and actually get a reasonably up to date version of docker and long term that's probably better than messing with Docker's external PPA. But this role also installs the additional python libraries and having it support xenial, focal, and jammy will be convenient for a smooth upgrade path.